### PR TITLE
fix(config): align resolve_config_value logic with README config priority

### DIFF
--- a/trae_agent/utils/config.py
+++ b/trae_agent/utils/config.py
@@ -144,14 +144,13 @@ def resolve_config_value(
     config_value: int | str | float | None,
     env_var: str | None = None,
 ) -> int | str | float | None:
-    """Resolve configuration value with priority: CLI > ENV > Config > Default."""
+    
+    """Resolve configuration value with priority: CLI > Config > ENV > Default."""
     if cli_value is not None:
         return cli_value
-
-    if env_var and os.getenv(env_var):
-        return os.getenv(env_var)
-
     if config_value is not None:
         return config_value
-
+    if env_var and os.getenv(env_var):
+        return os.getenv(env_var)
     return None
+


### PR DESCRIPTION
## Description

This pull request fixes an inconsistency between the `resolve_config_value` function implementation and the configuration priority documented in `README.md`.

## More Information

The `README.md` specifies the configuration priority as:

1. Command-line arguments (highest)
2. Configuration file values
3. Environment variables
4. Default values (lowest)

However, the original implementation of `resolve_config_value` prioritized environment variables over configuration file values, which contradicted the documentation:

```python
if cli_value is not None:
    return cli_value
if env_var and os.getenv(env_var):
    return os.getenv(env_var)
if config_value is not None:
    return config_value
return None
```

This PR updates the function to reflect the intended and documented priority:

```python
if cli_value is not None:
    return cli_value
if config_value is not None:
    return config_value
if env_var and os.getenv(env_var):
    return os.getenv(env_var)
return None
```
This change ensures consistency between documentation and implementation, helping prevent confusion for users and contributors.

## Validation

To validate this change:

Manually test a scenario where values are provided through CLI, config file, and environment variable.

Confirm that values are picked in the correct order: CLI > Config > ENV > Default.

## Linked Issues

Fixes #102

Let me know if you want help with writing test cases or validation examples.
