### PR TITLE
docs: fix README to reflect correct config priority (CLI > ENV > Config > Default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ base_url=https://ark.cn-beijing.volces.com/api/v3/
 
 **Configuration Priority:**
 1. Command-line arguments (highest)
-2. Configuration file values
-3. Environment variables
+2. Environment variables
+3. Configuration file values
 4. Default values (lowest)
 
 ```bash


### PR DESCRIPTION
## Description

This PR updates the README to reflect the correct configuration value resolution priority:

**CLI > ENV > Config > Default**

## More Information

The previous documentation incorrectly listed config file values above environment variables. This change aligns the README with the updated code behavior and common expectations across CLI tooling.

### Updated Section

**Before:**
```markdown
Configuration Priority:

1. Command-line arguments (highest)  
2. Configuration file values  
3. Environment variables  
4. Default values (lowest)
```
**After:**
```markdown
Configuration Priority:

1. Command-line arguments (highest)  
2. Environment variables  
3. Configuration file values  
4. Default values (lowest)
```

## Validation

This is a documentation-only change. No functional code changes are included.

## Linked Issues

Related to the logic fix in: https://github.com/bytedance/trae-agent/issues/102

